### PR TITLE
 Created External Brain type to include whether a brain is the "main" or "opponent" brain

### DIFF
--- a/python/trainer_config.yaml
+++ b/python/trainer_config.yaml
@@ -231,3 +231,29 @@ StudentRecurrentBrain:
     use_recurrent: true
     sequence_length: 32
     buffer_size: 128
+
+MainBrain:
+    batch_size: 32
+    normalize: false
+    num_layers: 1
+    hidden_units: 20
+    beta: 5.0e-3
+    gamma: 0.9
+    buffer_size: 256
+    max_steps: 5.0e5
+    summary_freq: 2000
+    time_horizon: 3
+    self_play: true
+
+GhostBrain:
+    batch_size: 32
+    normalize: false
+    num_layers: 1
+    hidden_units: 20
+    beta: 5.0e-3
+    gamma: 0.9
+    buffer_size: 256
+    max_steps: 5.0e5
+    summary_freq: 2000
+    time_horizon: 3
+    self_play: false

--- a/unity-environment/Assets/ML-Agents/Scripts/CoreBrainExternal.cs
+++ b/unity-environment/Assets/ML-Agents/Scripts/CoreBrainExternal.cs
@@ -1,16 +1,30 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace MLAgents
 {
     /// CoreBrain which decides actions via communication with an external system such as Python.
     public class CoreBrainExternal : ScriptableObject, CoreBrain
     {
+        private enum ExternalBrainType
+		{
+			Main = 0,
+			Opponent = 1
+		}
+
+		[SerializeField]
+		[Tooltip("External brain types")]
+		/// contains information of external brain type
+		private ExternalBrainType externalBrainType = ExternalBrainType.Main;
+
         /**< Reference to the brain that uses this CoreBrainExternal */
         public Brain brain;
 
-        Batcher brainBatcher;
+        MLAgents.Batcher brainBatcher;
 
         /// Creates the reference to the brain
         public void SetBrain(Brain b)
@@ -20,13 +34,16 @@ namespace MLAgents
 
         /// Generates the communicator for the Academy if none was present and
         ///  subscribe to ExternalCommunicator if it was present.
-        public void InitializeCoreBrain(Batcher brainBatcher)
+        public void InitializeCoreBrain(MLAgents.Batcher brainBatcher)
         {
             if (brainBatcher == null)
             {
                 brainBatcher = null;
-                throw new UnityAgentsException($"The brain {brain.gameObject.name} was set to" + " External mode" +
-                                               " but Unity was unable to read the" + " arguments passed at launch.");
+                throw new UnityAgentsException(string.Format("The brain {0} was set to" +
+                                                             " External mode" +
+                                                             " but Unity was unable to read the" +
+                                                             " arguments passed at launch.",
+                    brain.gameObject.name));
             }
             else
             {
@@ -44,12 +61,23 @@ namespace MLAgents
             {
                 brainBatcher.SendBrainInfo(brain.gameObject.name, agentInfo);
             }
+
+            return;
         }
 
-        /// Nothing needs to appear in the inspector 
+        /// Display options for external brain
         public void OnInspector()
         {
-
+			var serializedBrain = new SerializedObject(this);
+#if UNITY_EDITOR			
+			EditorGUILayout.LabelField("", GUI.skin.horizontalSlider);
+			EditorGUILayout.BeginHorizontal();
+			var ebt = serializedBrain.FindProperty("externalBrainType");
+			serializedBrain.Update();
+			EditorGUILayout.PropertyField(ebt , true);
+			serializedBrain.ApplyModifiedProperties();
+			EditorGUILayout.EndHorizontal();
+#endif		   
         }
     }
 }


### PR DESCRIPTION
- Added potential interface for brain types.

- Added a `self_play` flag to the trainer_config.yaml file. The parameter can be accessed by 
`trainer_parameters_dict[brain_name]['self_play']` in python code.
If it is false then it is a ghost brain otherwise it is the main brain.